### PR TITLE
Updating Dockerfile to accept a volume for the configuration directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,27 +18,11 @@ RUN \
     379CE192D401AB61
 
 ENV PUSHPIN_VERSION 1.20.1-1~bionic1
-ENV target app:8080
 
 # Install Pushpin
 RUN \
   apt-get update && \
   apt-get install -y pushpin=$PUSHPIN_VERSION
-
-# Configure Pushpin
-RUN \
-  sed -i \
-    -e 's/zurl_out_specs=.*/zurl_out_specs=ipc:\/\/\{rundir\}\/pushpin-zurl-in/' \
-    -e 's/zurl_out_stream_specs=.*/zurl_out_stream_specs=ipc:\/\/\{rundir\}\/pushpin-zurl-in-stream/' \
-    -e 's/zurl_in_specs=.*/zurl_in_specs=ipc:\/\/\{rundir\}\/pushpin-zurl-out/' \
-    /usr/lib/pushpin/internal.conf && \
-  sed -i \
-    -e 's/services=.*/services=mongrel2,m2adapter,zurl,pushpin-proxy,pushpin-handler/' \
-    -e 's/push_in_spec=.*/push_in_spec=tcp:\/\/\*:5560/' \
-    -e 's/push_in_http_addr=.*/push_in_http_addr=0.0.0.0/' \
-    -e 's/push_in_sub_spec=.*/push_in_sub_spec=tcp:\/\/\*:5562/' \
-    -e 's/command_spec=.*/command_spec=tcp:\/\/\*:5563/' \
-    /etc/pushpin/pushpin.conf
 
 # Cleanup
 RUN \
@@ -46,8 +30,12 @@ RUN \
   rm -fr /var/lib/apt/lists/* && \
   rm -fr /tmp/*
 
-# Define default command
-CMD ["sh", "-c", "/usr/bin/pushpin --merge-output --port=7999 --route=\"* ${target},over_http\""]
+# Add entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+
+# Define default entrypoint and command
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["pushpin", "--merge-output"]
 
 # Expose ports.
 # - 7999: HTTP port to forward on to the app

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-## Pushpin Dockerfile
+# Pushpin Dockerfile
 
 
 This repository contains **Dockerfile** of [Pushpin](http://pushpin.org/) for [Docker](https://www.docker.com/) published to the public [Docker Hub Registry](https://hub.docker.com/).
 
-### Base Docker Image
+## Base Docker Image
 
 * [ubuntu:18.04](https://hub.docker.com/_/ubuntu/)
 
-### Installation
+## Installation
 
 1. Install [Docker](https://www.docker.com/).
 
@@ -19,36 +19,37 @@ Alternatively, you can build an image from the `Dockerfile`:
 docker build -t fanout/pushpin .
 ```
 
-### Usage
+## Usage
 
 ```sh
-docker run -dt -p 7999:7999 --name pushpin --rm fanout/pushpin
+docker run \
+  -d \
+  -p 7999:7999 \
+  -p 5560-5563:5560-5563 \
+  --rm \
+  --name pushpin \
+  fanout/pushpin
 ```
 
-#### Attach app to accept traffic
-
-By default, Pushpin routes traffic to host "app" port 8080.
-
-1. Start a backend webserver container that exposes port 8080.
-
-2. Start a pushpin container by linking to the backend container:
-
-```sh
-docker run -dt -p 7999:7999 --name pushpin --link backend:app fanout/pushpin
-```
+By default, Pushpin routes traffic to a test handler.  See the [Getting Started Guide](https://pushpin.org/docs/getting-started/) for more information.
 
 Open `http://<host>:7999` to see the result.
 
-You can override the target with `-e`. For example:
+#### Configure Pushpin to route traffic
+
+To add custom Pushpin configuration to your Docker container, attach a configuration volume.
 
 ```sh
-docker run -dt -p 7999:7999 --name pushpin --link backend:app -e "target=app:8001" fanout/pushpin
+docker run \
+  -d \
+  -p 7999:7999 \
+  -p 5560-5563:5560-5563 \
+  -v $(pwd)/config:/etc/pushpin/ \
+  --rm \
+  --name pushpin \
+  fanout/pushpin
 ```
 
-#### Attach app to respond to traffic
+Note: The Docker entrypoint may make modifications to `pushpin.conf` so it runs properly in its container, exposing ports `7999`, `5560`, `5561`, `5562`, and `5563`.
 
-1. Start a responder container by linking to the pushpin container:
-
-```sh
-docker run -d --link pushpin:pushpin ubuntu bash -c "apt-get update; apt-get install -y curl; while true; do curl -s -d '{ \"items\": [ { \"channel\": \"test\", \"formats\": { \"http-stream\": { \"content\": \"hello there\n\" } } } ] }' http://pushpin:5561/publish ; sleep 1; done"
-```
+See project documentation for more on [configuring Pushpin](https://pushpin.org/docs/configuration/).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Configure Pushpin
+if [ -w /usr/lib/pushpin/internal.conf ]; then
+	sed -i \
+		-e 's/zurl_out_specs=.*/zurl_out_specs=ipc:\/\/\{rundir\}\/pushpin-zurl-in/' \
+		-e 's/zurl_out_stream_specs=.*/zurl_out_stream_specs=ipc:\/\/\{rundir\}\/pushpin-zurl-in-stream/' \
+		-e 's/zurl_in_specs=.*/zurl_in_specs=ipc:\/\/\{rundir\}\/pushpin-zurl-out/' \
+		/usr/lib/pushpin/internal.conf
+else
+	echo "docker-entrypoint.sh: unable to write to /usr/lib/pushpin/internal.conf, readonly"
+fi
+
+if [ -w /etc/pushpin/pushpin.conf ]; then
+	sed -i \
+		-e 's/services=.*/services=mongrel2,m2adapter,zurl,pushpin-proxy,pushpin-handler/' \
+		-e 's/push_in_spec=.*/push_in_spec=tcp:\/\/\*:5560/' \
+		-e 's/push_in_http_addr=.*/push_in_http_addr=0.0.0.0/' \
+		-e 's/push_in_sub_spec=.*/push_in_sub_spec=tcp:\/\/\*:5562/' \
+		-e 's/command_spec=.*/command_spec=tcp:\/\/\*:5563/' \
+		-e 's/^http_port=.*/http_port=7999/' \
+		/etc/pushpin/pushpin.conf
+else
+	echo "docker-entrypoint.sh: unable to write to /etc/pushpin/pushpin.conf, readonly"
+fi
+
+# Set routes with ${target} for backwards-compatibility.
+if [ -v target ]; then
+	echo "* ${target},over_http" > /etc/pushpin/routes
+fi
+
+exec "$@"


### PR DESCRIPTION
This remains backwards-compatible with older fanout/pushpin Docker images.

Example of how to take advantage of this:

```
docker run \
  -d \
  -p 7999:7999 \
  -p 5560-5563:5560-5563 \
  -v $(pwd)/examples/config:/etc/pushpin/ \
  --rm \
  --name pushpin \
  fanout/pushpin
```

The `routes` file in the example config directory routes to port 8000 on the Docker host.

Signed-off-by: Kevin Swiber <kswiber@gmail.com>