### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull the base image
-FROM ubuntu:22.04 as build
+FROM ubuntu:24.10 as build
 
 # Install deps
 RUN \
@@ -14,7 +14,7 @@ RUN \
 
 WORKDIR /build
 
-ENV VERSION 1.40.1
+ENV VERSION 1.40.2
 
 ADD https://github.com/fastly/pushpin/releases/download/v${VERSION}/pushpin-${VERSION}.tar.bz2 .
 
@@ -26,7 +26,7 @@ RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc
 RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc check
 RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc INSTALL_ROOT=/build/out install
 
-FROM ubuntu:22.04
+FROM ubuntu:24.10
 MAINTAINER Justin Karneges <jkarneges@fastly.com>
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 
 WORKDIR /build
 
-ENV VERSION 1.40.2
+ENV VERSION 1.40.1
 
 ADD https://github.com/fastly/pushpin/releases/download/v${VERSION}/pushpin-${VERSION}.tar.bz2 .
 


### PR DESCRIPTION
**What**

- Bumps the base image version from ubuntu:22.04 to ubuntu:24.10
- Bumps the pushpin version to `1.40.2`

**Why**

- We use pushpin and our scanners flagged some vulnerabilities that
  exist in 22.04. These vulnerabilities are resolved in 24.10.

![Screenshot 2024-11-26 at 10 28 39](https://github.com/user-attachments/assets/3b7ddf81-1f9c-4177-bcc0-482dea7c580a)
![Screenshot 2024-11-26 at 10 27 53](https://github.com/user-attachments/assets/4465f00e-23b1-41a6-b450-fecfceb29053)

