### PR TITLE
chore: Turn back on latest tagging for docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,13 +1,18 @@
 name: Docker
 
 on:
-  push:
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+    inputs:
+      set_latest_tag:
+        description: 'Set to true to tag the image with `latest`'
+        required: true
+        default: false
+        type: boolean
 
 env:
   REGISTRY: docker.io
   IMAGE_NAME: fanout/pushpin
+  SET_LATEST: ${{ github.event.inputs.set_latest_tag }}
 
 jobs:
   build:
@@ -41,7 +46,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
-            latest=false
+            latest=${{ env.SET_LATEST }}
           tags: |
             type=ref,event=branch,pattern={{branch}}
             type=semver,pattern={{version}},value=${{ env.SOURCE_VERSION }}
@@ -97,7 +102,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
-            latest=false
+            latest=${{ env.SET_LATEST }}
           tags: |
             type=ref,event=branch,pattern={{branch}}
             type=semver,pattern={{version}},value=${{ env.SOURCE_VERSION }}


### PR DESCRIPTION
Previously we turned this off to test that the multi-arch builds actually work. We've verified that we were successfully able to build and push a mulit-arch image, so now we can turn back on the latest tagging.

This new approach changes things just a bit. It turns this from relying on new tag pushes to instead being manually activated. Deploying now will involved someone activating the github action to build the new docker container and being able to choose whether it tags the image it will build as "latest" or not.