### PR TITLE
install qt 6 libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ MAINTAINER Justin Karneges <jkarneges@fastly.com>
 
 RUN \
   apt-get update && \
-  apt-get install -y --no-install-recommends libqt5core5a libqt5network5 libzmq5 && \
+  apt-get install -y --no-install-recommends libqt6core6 libqt6network6 libzmq5 && \
   apt-get -y autoremove && \
   apt-get -y clean && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Missed this in #24.

```
% docker-compose build                                         
[+] Building 0.5s (19/19) FINISHED                                                                                 docker:colima
 => [pushpin internal] load build definition from Dockerfile                                                                0.1s
 => => transferring dockerfile: 1.49kB                                                                                      0.0s
 => [pushpin internal] load .dockerignore                                                                                   0.0s
 => => transferring context: 2B                                                                                             0.0s
 => [pushpin internal] load metadata for docker.io/library/ubuntu:24.10                                                     0.0s
 => [pushpin] https://github.com/fastly/pushpin/releases/download/v1.40.1/pushpin-1.40.1.tar.bz2                            0.3s
 => [pushpin internal] load build context                                                                                   0.0s
 => => transferring context: 42B                                                                                            0.0s
 => [pushpin build 1/9] FROM docker.io/library/ubuntu:24.10                                                                 0.0s
 => CACHED [pushpin stage-1 2/4] RUN   apt-get update &&   apt-get install -y --no-install-recommends libqt6core6 libqt6ne  0.0s
 => CACHED [pushpin build 2/9] RUN   apt-get update &&   apt-get install -y bzip2 pkg-config make g++ rustc cargo libssl-d  0.0s
 => CACHED [pushpin build 3/9] WORKDIR /build                                                                               0.0s
 => CACHED [pushpin build 4/9] ADD https://github.com/fastly/pushpin/releases/download/v1.40.1/pushpin-1.40.1.tar.bz2 .     0.0s
 => CACHED [pushpin build 5/9] RUN tar xf pushpin-1.40.1.tar.bz2 && mv pushpin-1.40.1 pushpin                               0.0s
 => CACHED [pushpin build 6/9] WORKDIR /build/pushpin                                                                       0.0s
 => CACHED [pushpin build 7/9] RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc                                                0.0s
 => CACHED [pushpin build 8/9] RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc check                                          0.0s
 => CACHED [pushpin build 9/9] RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc INSTALL_ROOT=/build/out install                0.0s
 => CACHED [pushpin stage-1 3/4] COPY --from=build /build/out/ /                                                            0.0s
 => CACHED [pushpin stage-1 4/4] COPY docker-entrypoint.sh /usr/local/bin/                                                  0.0s
 => [pushpin] exporting to image                                                                                            0.0s
 => => exporting layers                                                                                                     0.0s
 => => writing image sha256:cd1bfd606cc5100de992ca2009d1f80c0049324768e94f8284f78f74e11ce231                                0.0s
 => => naming to docker.io/fanout/pushpin:1.40.1-1                                                                          0.0s
 => [pushpin] resolving provenance for metadata file                                                                        0.0s
[+] Building 1/1
 ✔ pushpin  Built                                                                                                           0.0s 
% docker run -it --rm fanout/pushpin:1.40.1-1 pushpin --version
Detected locale "C" with character encoding "ANSI_X3.4-1968", which is not UTF-8.
Qt depends on a UTF-8 locale, and has switched to "C.UTF-8" instead.
If this causes problems, reconfigure your locale. See the locale(1) manual
for more information.
pushpin 1.40.1
```