### PR TITLE
chore: Remove branch tagging from docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,6 @@ jobs:
           flavor: |
             latest=${{ env.SET_LATEST }}
           tags: |
-            type=ref,event=branch,pattern={{branch}}
             type=semver,pattern={{version}},value=${{ env.SOURCE_VERSION }}
 
       - name: Derive arch-suffixed tags as output
@@ -104,7 +103,6 @@ jobs:
           flavor: |
             latest=${{ env.SET_LATEST }}
           tags: |
-            type=ref,event=branch,pattern={{branch}}
             type=semver,pattern={{version}},value=${{ env.SOURCE_VERSION }}
 
       - name: Login


### PR DESCRIPTION
Previously I added the branch tagging because it seemed like it could be useful for building from PRs, but since we've changed the way the build works it ends up pushing a `master` tag now.

This tag can be confusing because it's unlikely to be up to date with actual master, so it is being removed.