### PR TITLE
set LANG env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ COPY --from=build /build/out/ /
 # Add entrypoint script
 COPY docker-entrypoint.sh /usr/local/bin/
 
+ENV LANG C.UTF-8
+
 # Define default entrypoint and command
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["pushpin", "--merge-output"]


### PR DESCRIPTION
Qt depends on a UTF-8 locale. This gets rid of the warning on startup, which started appearing when we upgraded to Qt 6.