### PR TITLE
Bump docker container build number

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,4 +4,4 @@ services:
       context: .
       args:
         VERSION: 1.41.0
-    image: fanout/pushpin:1.41.0
+    image: fanout/pushpin:1.41.0-1


### PR DESCRIPTION
To get some of the latest docker build changes in we're bumping the build number so generate a new image.