### PR TITLE
fix: Give docker build tags explicit vars

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,11 +8,21 @@ on:
         required: true
         default: false
         type: boolean
+      build_version:
+        description: 'The version of pushpin to build and push (ex: 1.40.1)'
+        required: true
+        type: string
+      build_tag:
+        description: 'The tag to use for the docker image (ex: 1.40.1) (ex: 1.40.1-2)'
+        required: true
+        type: string
 
 env:
   REGISTRY: docker.io
   IMAGE_NAME: fanout/pushpin
   SET_LATEST: ${{ github.event.inputs.set_latest_tag }}
+  BUILD_VERSION: ${{ github.event.inputs.build_version }}
+  BUILD_TAG: ${{ github.event.inputs.build_tag }}
 
 jobs:
   build:
@@ -37,9 +47,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Get source version
-        run: echo "SOURCE_VERSION=$(grep VERSION compose.yaml | awk '{print $2}')" >> "$GITHUB_ENV"
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -48,7 +55,8 @@ jobs:
           flavor: |
             latest=${{ env.SET_LATEST }}
           tags: |
-            type=semver,pattern={{version}},value=${{ env.SOURCE_VERSION }}
+            type=ref,event=branch,pattern={{branch}}
+            type=semver,pattern={{version}},value=${{ env.BUILD_TAG }}
 
       - name: Derive arch-suffixed tags as output
         id: archtags
@@ -78,7 +86,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            VERSION=${{ env.SOURCE_VERSION }}
+            VERSION=${{ env.BUILD_VERSION }}
           tags: ${{ steps.archtags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -92,9 +100,6 @@ jobs:
       - name: Code checkout
         uses: actions/checkout@v4
 
-      - name: Get source version
-        run: echo "SOURCE_VERSION=$(grep VERSION compose.yaml | awk '{print $2}')" >> "$GITHUB_ENV"
-
       - name: Docker meta (same base tags)
         id: meta
         uses: docker/metadata-action@v5
@@ -103,7 +108,8 @@ jobs:
           flavor: |
             latest=${{ env.SET_LATEST }}
           tags: |
-            type=semver,pattern={{version}},value=${{ env.SOURCE_VERSION }}
+            type=ref,event=branch,pattern={{branch}}
+            type=semver,pattern={{version}},value=${{ env.BUILD_TAG }}
 
       - name: Login
         uses: docker/login-action@v3


### PR DESCRIPTION
The previous changes to docker builds did not carry over the ability to differentiate the docker image build tags from the version of the software being build. This is important due to the fact that sometimes we'll want to rebuild the docker image because of docker specific changes but we don't want to force push a new digest over an already established docker tag.

This PR moves `build_tag` and `build_version` to explicitly defined variables so that it's a bit easier to grok where these values are coming from and where they are being inserted.