### PR TITLE
fix: Remove docker branch tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,6 @@ jobs:
           flavor: |
             latest=${{ env.SET_LATEST }}
           tags: |
-            type=ref,event=branch,pattern={{branch}}
             type=semver,pattern={{version}},value=${{ env.BUILD_TAG }}
 
       - name: Derive arch-suffixed tags as output
@@ -108,7 +107,6 @@ jobs:
           flavor: |
             latest=${{ env.SET_LATEST }}
           tags: |
-            type=ref,event=branch,pattern={{branch}}
             type=semver,pattern={{version}},value=${{ env.BUILD_TAG }}
 
       - name: Login


### PR DESCRIPTION
I mistakenly reintroduced a regression where the docker build tagged the branch again. This removes those tags once again.