### PR TITLE
Swap container to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull the base image
-FROM ubuntu:24.10 as build
+FROM ubuntu:24.04 as build
 
 # Install deps
 RUN \
@@ -26,7 +26,7 @@ RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc
 RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc check
 RUN make RELEASE=1 PREFIX=/usr CONFIGDIR=/etc INSTALL_ROOT=/build/out install
 
-FROM ubuntu:24.10
+FROM ubuntu:24.04
 MAINTAINER Justin Karneges <jkarneges@fastly.com>
 
 RUN \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains **Dockerfile** of [Pushpin](http://pushpin.org/) for [D
 
 ## Base Docker Image
 
-* [ubuntu:24.10](https://hub.docker.com/_/ubuntu/)
+* [ubuntu:24.04](https://hub.docker.com/_/ubuntu/)
 
 ## Installation
 


### PR DESCRIPTION
Container is currently built on top of 24.10 which is [EOL](https://ubuntu.com/about/release-cycle). 24.04 is older but choosing an LTS release seems wise for this sort of thing. I can update this to 25.10 if you prefer though.

As a side thought, is there interest in providing slim/debian or alpine builds? I can add builds for that if there is